### PR TITLE
Quick fix for CDH4 / MRv2.

### DIFF
--- a/dumbo/backends/streaming.py
+++ b/dumbo/backends/streaming.py
@@ -62,7 +62,8 @@ class StreamingIteration(Iteration):
         addedopts = opts.filter(keys)
         opts.remove(*keys)
 
-        hadooplib = findhadoop(addedopts['hadooplib'][0])
+        hadoop = findhadoop(addedopts['hadoop'][0])
+        hadooplib = findhadoop(addedopts['hadooplib'][0]) if 'hadooplib' in addedopts else hadoop
         streamingjar = findjar(hadooplib, 'streaming')
         if not streamingjar:
             print >> sys.stderr, 'ERROR: Streaming jar not found'
@@ -194,7 +195,6 @@ class StreamingIteration(Iteration):
         if tmpjars:
             opts.add('jobconf', 'tmpjars=%s' % ','.join(tmpjars))
 
-        hadoop = findhadoop(addedopts['hadoop'][0])
         cmd = hadoop + '/bin/hadoop jar ' + streamingjar
         retval = execute(cmd, opts, hadenv)
 

--- a/dumbo/util.py
+++ b/dumbo/util.py
@@ -284,7 +284,8 @@ def findjar(hadoop, name):
         os.path.join(hadoop, 'mapred', 'contrib', name),
         os.path.join(hadoop, 'contrib', name),
         os.path.join(hadoop, 'mapred', 'contrib'),
-        os.path.join(hadoop, 'contrib')
+        os.path.join(hadoop, 'contrib'),
+        hadoop
     ])
     regex = re.compile(r'hadoop.*%s.*\.jar' % name)
 


### PR DESCRIPTION
This adds a -hadooplib command-line switch to tell dumbo where
hadoop-streaming.jar is stored, along with an addition to the jar search path.
It also uses 'hadoop fs' instead of 'hdfs dfs' since it's easier to find.

This may not be the best long-term solution, but it seems to work for now.  I have not tested with MRv1 or anything off the beaten path.  Addresses Issue #53.
