### PR TITLE
Fix #62 Added path as key[0] for MultiMapper

### DIFF
--- a/dumbo/lib/__init__.py
+++ b/dumbo/lib/__init__.py
@@ -125,7 +125,7 @@ class MultiMapper(object):
     def __call__normalkey(self, data):
         mappers = self.mappers
         for key, value in data:
-            path, key = key
+            path = key[0]
             for pattern, mapper in mappers:
                 if pattern in path:
                     for output in mapper(key, value):
@@ -135,7 +135,6 @@ class MultiMapper(object):
         mappers = self.mappers
         for key, value in data:
             path = key.body[0]
-            key.body = key.body[1]
             for pattern, mapper in mappers:
                 if pattern in path:
                     for output in mapper(key, value):


### PR DESCRIPTION
Please check the fix. Please note that there is small incompatibility with previous versions, i.e. if somebody uses keys in multimappers, however this is very rare. Now a developer will have access to filepaths and should implicitly ignore them if he os she wants...
