### PR TITLE
Fix #62 Optional path argument in JoinMapper

### DIFF
--- a/dumbo/core.py
+++ b/dumbo/core.py
@@ -463,7 +463,7 @@ def valwrapper(data, valfunc):
 
 def mapfunc_iter(data, mapfunc):
     for (key, value) in data:
-        for output in mapfunc(key, value):
+        for output in mapfunc(key, value) or ():
             yield output
 
 
@@ -478,7 +478,7 @@ def itermap(data, mapfunc, valfunc=None):
 
 def redfunc_iter(data, redfunc):
     for (key, values) in data:
-        for output in redfunc(key, values):
+        for output in redfunc(key, values) or ():
             yield output
 
 

--- a/dumbo/lib/__init__.py
+++ b/dumbo/lib/__init__.py
@@ -171,7 +171,7 @@ class JoinMapper(object):
         if hasattr(mapper, 'close'):
             self.closefunc = mapper.close
         mapper_call = mapper
-        if type(self.mapper) in (types.ClassType, type):
+        if isinstance(mapper_call, mrbase_class):
             mapper_call = mapper.__call__
         self.mapper = mapper
         if not inspect.getargspec(mapper_call).keywords:

--- a/dumbo/lib/__init__.py
+++ b/dumbo/lib/__init__.py
@@ -183,7 +183,7 @@ class JoinMapper(object):
 
     def __call__(self, key, value, **kwargs):
         key.isprimary = self.isprimary
-        for k, v in self.mapper(key.body, value, **kwargs):
+        for k, v in self.mapper(key.body, value, **kwargs) or ():
             jk = copy(key)
             jk.body = k
             yield jk, v
@@ -208,14 +208,12 @@ class JoinCombiner(object):
     def __call__(self, key, values):
         if key.isprimary:
             self._key = key.body
-            output = self.primary(key.body, values)
-            if output:
-                for k, v in output:
-                    jk = copy(key)
-                    jk.body = k
-                    yield jk, v
+            for k, v in self.primary(key.body, values) or ():
+                jk = copy(key)
+                jk.body = k
+                yield jk, v
         elif not self.secondary_blocked(key.body):
-            for k, v in self.secondary(key.body, values):
+            for k, v in self.secondary(key.body, values) or ():
                 jk = copy(key)
                 jk.body = k
                 yield jk, v


### PR DESCRIPTION
Now to get source path from the mapper routine just add **kwargs to the arguments list. Here are some examples.

```
@dumbo.decor.primary
def map_primary(key, value, **kwargs):
  key, value = value.strip().split('\t')
  print >> sys.stderr, key, value, kwargs['path']
  yield key, value
```

Or you can specify desired argument directly

```
@dumbo.decor.primary
def map_primary(key, value, path, **kwargs):
  key, value = value.strip().split('\t')
  print >> sys.stderr, key, value, path
  yield key, value
```

Callable instances are also supported

```
@dumbo.decor.secondary
class MapSecondary(object):
  def __call__(self, key, value, path, **kwargs):
    key, value = value.strip().split(' ')
    print >> sys.stderr, value, path
    yield key, value
```

And previous mapper interface is working aswell

```
@dumbo.decor.primary
def map_primary(key, value):
  key, value = value.strip().split('\t')
  yield key, value
```

This approach allows easily extend interface to pass other arguments in the future
