### PR TITLE
Fix JoinKey sort order and allow comparison with other types.

### DIFF
--- a/dumbo/backends/common.py
+++ b/dumbo/backends/common.py
@@ -93,11 +93,11 @@ class JoinKey(object):
         self.isprimary = isprimary
   
     def __cmp__(self, other):
-        bodycmp = cmp(self.body, other.body)
-        if bodycmp:
-            return bodycmp
+        if isinstance(other, JoinKey):
+            # For isprimary, order is switched because we want True to sort before False
+            return cmp(self.body, other.body) or cmp(other.isprimary, self.isprimary)
         else:
-            return cmp(self.isprimary, other.isprimary)
+            return -1     # JoinKeys arbitrarily come before everything else
 
     @classmethod
     def fromjoinkey(cls, jk):


### PR DESCRIPTION
Primary and secondary `JoinKey`s seem to compare backwards when using the Python backend (e.g., with mapredtest), due to this code in `JoinKey.__cmp__()`:

```
return cmp(self.isprimary, other.isprimary)
```

because when comparing the `.isprimary` attribute of a JoinKey, `False` sorts before `True`.

This isn't noticed using the Unix or Hadoop backends because `isprimary` serializes to `1` for primary and `2` for secondary.

This patch also allows comparing a `JoinKey` to any other type without crashing (it arbitrarily sorts first).  This is useful in a situation like:

```
def reducer(keysvals):
    key, val = next(keysvals, (defaultkey, defaultval))
    if key == defaultkey:
        ...
```
