### PR TITLE
Catch too many or too few outputs with mapredtest.

### DIFF
--- a/tests/testmapredtest.py
+++ b/tests/testmapredtest.py
@@ -44,12 +44,8 @@ class MRTestCase(unittest.TestCase):
             (1, "hello")
         ]
         #each 3 map calls will yield with both params 
-        output = [('foo', 'bar'),
-                  ('one', '1'),('foo', 'bar'),
-                  ('one', '1'),('foo', 'bar'),
-                  ('one', '1')]
-        params = [('foo', 'bar'),
-                  ('one', '1')]
+        output = [('foo', 'bar'), ('one', '1')] * 2
+        params = [('foo', 'bar'), ('one', '1')]
         ReduceDriver(reducer_with_params).with_params(params).with_input(input).with_output(output).run()
        
     def testreducer(self):
@@ -65,6 +61,13 @@ class MRTestCase(unittest.TestCase):
         ]
         output = [('hello', 1), ('me', 1), ('test', 2)]
         MapReduceDriver(mapper, reducer).with_input(input).with_output(output).run()
+
+    def test_toomany(self):
+        input_ = [(0, 'a b c')]
+        output = [('a', 1), ('b', 1)]
+        self.assertRaises(AssertionError, MapDriver(mapper).with_input(input_).with_output(output).run)
+        output = [('a', 1), ('b', 1), ('c', 1), ('d', 1)]
+        self.assertRaises(AssertionError, MapDriver(mapper).with_input(input_).with_output(output).run)
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(MRTestCase)


### PR DESCRIPTION
mapredtest was only iterating over the actual output, silently ignoring any
further expected output.  In the extreme case, a mapper or reducer that output
nothing would always pass.  The error when a map/reduce did not produce enough
output was also not helpful.  This patch factors iterator comparison into a
function to reduce duplicated code, and adds and corrects tests.
